### PR TITLE
Remove dependency to fastlane

### DIFF
--- a/apprepo.gemspec
+++ b/apprepo.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # fastlane dependencies
-  spec.add_dependency 'fastlane'
-  spec.add_dependency 'fastlane_core', '~> 0'
   spec.add_dependency 'net-ssh', '~> 2.6'
   spec.add_dependency 'net-sftp', '~> 2.1'
   spec.add_dependency 'json', '= 1.8.1' # required by fastlane


### PR DESCRIPTION
With an upcoming _fastlane_ release it is important to remove the dependency to _fastlane_ and _fastlane_core_, see https://github.com/fastlane/fastlane/issues/7412 for more information